### PR TITLE
Update Docker Compose Gemfile.lock and setup instructions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.0-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.14.0-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.0-x86_64-darwin)
@@ -280,6 +282,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.3-aarch64-linux)
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
@@ -313,6 +316,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   arm64-darwin-23
   x86_64-darwin-21

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ To get started with the app, clone the repo and then install the needed gems. Yo
 ```
 git clone https://github.com/JetBrains/sample_rails_app_7th_ed 
 cd sample_rails_app_7th_ed/
+docker compose up --detach
+docker compose exec web rake db:setup
 ```
 
 Add Docker Compose Ruby SDK in RubyMine settings:
@@ -27,23 +29,24 @@ Add Docker Compose Ruby SDK in RubyMine settings:
 4. Press `OK`
 5. Select added SDK in `Ruby SDK and Gems` and press `OK`
 
-Next, migrate the database:
+Go to a test file in RubyMine and click the green arrow to run a test.
+
+## Rake Tasks
+
+Open `Tools > Run Rake Task...` to access the Rake tasks.
+
+### Update the Database
+
+If the database is ever out-of-date, run the database migration Rake task from the Rake task list.
 
 ```
 rake db:migrate
 ```
 
-Finally, run the test suite to verify that everything is working correctly:
+### Run tests
+
+To try all the tests, run the `test` Rake task.
 
 ```
 rake test
-```
-
-If the test suite passes, you’ll be ready to seed the database with sample users and run the app in a local server:
-
-```
-rake db:seed
-```
-```
-rails server
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # Switch to 'postgresql' in config/database.yml before running 'docker-compose up'
-version: '3'
 services:
   db:
     image: postgres


### PR DESCRIPTION
The Gemfile lockfile didn't yet have support for ARM-based linux, so this adds that.

The Docker Compose file had the now-deprecated `version` field, so I removed that.

I also updated the README file to run the setup and test instructions against the Docker container instead of outside the docker container.